### PR TITLE
Add support for "Groups" tag in Info.xml

### DIFF
--- a/tests/parse-node.test.ts
+++ b/tests/parse-node.test.ts
@@ -162,6 +162,10 @@ describe('Info.xml Got Parsed', () => {
         <Id>1</Id>
         <Website>https://example.com</Website>
         <Version>1.0.0</Version>
+        <Groups>
+            <element>category 1</element>
+            <element>testGroup2</element>
+        </Groups> 
     </fomod>`, {contentType: 'text/xml'}).window.document;
 
     const infoObj = parseInfoDoc(infoDoc);
@@ -187,6 +191,10 @@ describe('Info.xml Got Parsed', () => {
 
     test('Version Is Correct', () => {
         expect(infoObj.data.Version).toBe('1.0.0');
+    });
+
+    test('Groups Is Correct', () => {
+        expect(infoObj.data.Groups).toStrictEqual(['category 1', 'testGroup2']);
     });
 
     describe('Converted Back Into Element Properly', () => {


### PR DESCRIPTION
This PR aims to add support for the **Groups** tag found in the `Info.xml`.

The **Groups** tag, while widely used in many mods, is not in the current version of the schema definition (that I could find).
However, as so many mods use it I found it useful to implement it.

```xml
<fomod xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://bellcubedev.github.io/site-testing/assets/site/misc/Info.xsd">
    <Name>The BANANA Mod</Name>
    <Author>BellCube</Author>
    <Id>1</Id>
    <Website>https://example.com</Website>
    <Version>1.0.0</Version>
    <Groups>
        <element>category 1</element>
        <element>testGroup2</element>
    </Groups> 
</fomod>
```